### PR TITLE
symlinks.sh: avoid creating symlinks inside directories

### DIFF
--- a/efm2riot/templates/boards/board/include/periph_conf.h
+++ b/efm2riot/templates/boards/board/include/periph_conf.h
@@ -34,9 +34,16 @@ extern "C" {
  * @brief   Clock configuration
  * @{
  */
+#ifndef CLOCK_HF
 #define CLOCK_HF            cmuSelect_HFXO
+#endif
+#ifndef CLOCK_CORE_DIV
 #define CLOCK_CORE_DIV      cmuClkDiv_1
+#endif
+#ifndef CLOCK_LFA
 #define CLOCK_LFA           cmuSelect_LFXO
+#endif
+#ifndef CLOCK_LFB
 {% strip 2 %}
     {% if board in ["stk3200"] %}
         #define CLOCK_LFB           cmuSelect_CORELEDIV2
@@ -44,9 +51,12 @@ extern "C" {
         #define CLOCK_LFB           cmuSelect_LFXO
     {% endif %}
 {% endstrip %}
+#endif
 {% strip 2 %}
     {% if board in ["slstk3401a"] %}
+        #ifndef CLOCK_LFE
         #define CLOCK_LFE           cmuSelect_LFXO
+        #endif
     {% endif %}
 {% endstrip %}
 /** @} */

--- a/efm2riot/templates/contrib/symlinks.sh
+++ b/efm2riot/templates/contrib/symlinks.sh
@@ -9,11 +9,11 @@ TARGET=$1
 # Symlink all boards into 'RIOT_ROOT/boards/'.
 for board in $BOARDS
 do
-    ln -sF `realpath "$SOURCE/boards/$board"` "$TARGET/boards/$board"
+    ln -sf `realpath "$SOURCE/boards/$board"` "$TARGET/boards/"
 done
 
 # Symlink all families into 'RIOT_ROOT/cpu/'.
 for family in $FAMILIES
 do
-    ln -sF `realpath "$SOURCE/cpu/$family"` "$TARGET/cpu/$family"
+    ln -sf `realpath "$SOURCE/cpu/$family"` "$TARGET/cpu/"
 done


### PR DESCRIPTION
This change makes symlinks.sh idempotent; with the full name of the
to-be-created symlink specified, a re-run would create a symlink to the
$EFM2Riot/dist/cpu/$X inside $RIOT/cpu/$X, which would either be a
symlink already and thus create $EFM2Riot/dist/cpu/$X/$X, or (in case
there is a directory around in the source tree because that CPU exists
upstream or the directory was not removed after a branch switch) inside
that directory.

The updated version now complains about existing directories (eg.

```
ln: failed to create symbolic link '/home/chrysn/git/RIOT/boards/slwstk6220a/slwstk6220a': File exists
ln: failed to create symbolic link '/home/chrysn/git/RIOT/cpu/ezr32wg/ezr32wg': File exists
```

) but does not create symlinks in the wrong place.

The -F option was changed to -f because -F makes no sense here ("allow
the superuser to attempt to hard link directories"), probably -f was
meant, and this makes the script overwrite existing symlinks.
