### PR TITLE
STK boards: allow overriding clock sources per application

### DIFF
--- a/efm2riot/templates/boards/board/include/periph_conf.h
+++ b/efm2riot/templates/boards/board/include/periph_conf.h
@@ -34,9 +34,16 @@ extern "C" {
  * @brief   Clock configuration
  * @{
  */
+#ifndef CLOCK_HF
 #define CLOCK_HF            cmuSelect_HFXO
+#endif
+#ifndef CLOCK_CORE_DIV
 #define CLOCK_CORE_DIV      cmuClkDiv_1
+#endif
+#ifndef CLOCK_LFA
 #define CLOCK_LFA           cmuSelect_LFXO
+#endif
+#ifndef CLOCK_LFB
 {% strip 2 %}
     {% if board in ["stk3200"] %}
         #define CLOCK_LFB           cmuSelect_CORELEDIV2
@@ -44,9 +51,12 @@ extern "C" {
         #define CLOCK_LFB           cmuSelect_LFXO
     {% endif %}
 {% endstrip %}
+#endif
 {% strip 2 %}
     {% if board in ["slstk3401a"] %}
+        #ifndef CLOCK_LFE
         #define CLOCK_LFE           cmuSelect_LFXO
+        #endif
     {% endif %}
 {% endstrip %}
 /** @} */


### PR DESCRIPTION
An application can now add a -DCLOCK_LFB=cmuSelect_CORELEDIV2 to its
Makefile without getting preprocessor redefinition errors.

This is required to utilize the full supported range of baud rates on
LEUART devices, for example.

---

This might be a little controversial; I'd focus on CLOCK_LFB (which I need to change) here, and if you think CLOCK_HF should not be changable, drop that part.

It seems to be a RIOT position that the board file does not fully define all the hardware connections, but that details like whether a serial interface is used and which baud rate it is used with can be decided at runtime (evidenced by the UART setup functions). With the gecko boards, the usable baud rates depend on which clock source CLOCK_LFB is configured for. (The LF clocks are also used for several other peripherals and features, but let's stick with serial lines to keep things concise). An IMO ideal solution would be the possibility to have the peripherals agree on the clock source they need at run time, but way to go for that. In the meantime, overriding the board defaults per application seems to be the most viable solution.
